### PR TITLE
Fix #42 - assorted model changes

### DIFF
--- a/model-desc/icdc-model-props.yml
+++ b/model-desc/icdc-model-props.yml
@@ -196,10 +196,8 @@ PropDefinitions:
     Type: string
   cohort_dose:
     Desc: intended or protocol dose
-    Type:
-      units:
-        - mg/kg
-      value_type: number
+    Type: string
+    # setting this as string so as to accommodate a lack of consistency in the way in which dosing is quoted within the COTC007B study, which will otherwise confound data loading for MVP
 # cycle props
   cycle_number:
     Src: COURSE INIT/CINIT/1
@@ -433,7 +431,7 @@ PropDefinitions:
   #   Desc:
   #   Src:
   #   Type: string
-  file_locations:
+  file_location:
     Type: string
 # follow_up props
   contact_type:
@@ -764,6 +762,8 @@ PropDefinitions:
     Type:
     - normal
     - tumor
+    - not applicable
+    # including this as an acceptable value to account for the difficulty in assigning blood samples from patients with cancer as either of the other two acceptable values
     Req: true
   length_of_tumor:
     Desc: length of the tumor from which a tumor sample was derived
@@ -796,6 +796,11 @@ PropDefinitions:
     Src: '?'
     Type: string
     Req: true
+  sample_site:
+    Desc: indicator of anatomical location from which sample was acquired # proactively include this for future use?
+    Src: '?'
+    Type:
+    - http://localhost/terms/domain/anatomical_location
   sample_type:
     Desc: indicator as to the physical nature of the biomaterial - tissue, blood, urine, etc.
     Src: '?'
@@ -803,6 +808,10 @@ PropDefinitions:
     - tissue
     - blood
     Req: true
+  specific_sample_pathology:
+     Desc: indicator of the specific pathology associated with a sample, e.g. squamous cell carcinoma # proactively include this for future use?
+     Src: '?'
+     Type: TBD #enum list of acceptable values
   total_tissue_area:
     Desc: for the NCATS study, area within the slide's analysis area represented by tissue
     Src: '?'

--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -187,8 +187,12 @@ Nodes:
       - sample_id
       - sample_type
       # indicator as to the nature of the biomaterial - tissue, blood, urine, etc.
+      - sample_site
+      # indicator of anatomical location from which sample was acquired
       - general_sample_pathology
-      # indicator as to whether the sample is normal or tumor derived
+      # indicator as to whether the sample is normal or tumor derived - proactively include this for future use?
+      - specific_sample_pathology
+      # indicator of the specific pathology associated with a sample, e.g. squamous cell carcinoma - proactively include this for future use?
       - date_of_sample_collection
       - necropsy_sample
       - length_of_tumor
@@ -224,7 +228,7 @@ Nodes:
       - file_status
       # enumerated
       - uuid
-      - file_locations
+      - file_location
   image:
     Props: null
   physical_exam:
@@ -351,7 +355,7 @@ Relationships:
       # to accomodate Cases not maaped to any Cohrt, either due to error or by design 
       - Src: cohort
         Dst: study
-    # to accomodate a Study having Cases that should be grouped into Cohorts, but where Study Arms don't apply      
+      # to accomodate a Study having Cases that should be grouped into Cohorts, but where Study Arms don't apply      
     Props: null
   of_case:
     Mul: many_to_one
@@ -371,6 +375,12 @@ Relationships:
       - Src: sample
         Dst: case
     # to accommodate a Sample being directly associated with a Case, rather than being only indirectly associated with a Case through a Visit etc.
+      - Src: visit
+        Dst: case
+    # to accommodate situations in which a Visit cannot be unambiguously associated with a treatment Cycle
+      - Src: adverse_event
+        Dst: case
+    # required because adverse event observations are tied to date of onset rather than being tied to the date of the visit at which they were reported 
     Props: null
   of_study_arm:
     Mul: many_to_many
@@ -385,6 +395,9 @@ Relationships:
         Dst: study
       - Src: principal_investigator
         Dst: study
+      - Src: file
+        Dst: study
+        Mul: many to one
     Props: null
   of_agent:
     Mul: many_to_one
@@ -427,8 +440,7 @@ Relationships:
         Dst: visit
       - Src: lab_exam
         Dst: visit
-      - Src: adverse_event
-        Dst: visit
+    # removed relationship between adverse event and visit because adverse events are tied to date of onset rather than being tied to the date of the visit at which they were reported 
       - Src: disease_extent
         Dst: visit
       - Src: vital_signs

--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -397,7 +397,7 @@ Relationships:
         Dst: study
       - Src: file
         Dst: study
-        Mul: many to one
+        Mul: many_to_one
     Props: null
   of_agent:
     Mul: many_to_one


### PR DESCRIPTION
Assorted model updates required in order to support upload of minimum viable content for MVP release:
Need a relationship from File directly to Study, for study-level data files
Need a relationship from Visit to Case, for situations where a Visit can't be unambiguously mapped to a Cycle
Need a relationship from Adverse Event to Case, to replace the relationship from Adverse Event to Visit - AEs are based on date of onset, not visit
Advocate proactively adding sample_site and specific_sample_pathology properties to Sample
Need to add "not applicable" as an acceptable term for general_sample_pathology to accommodate blood samples
Need to remove the s from the file_locations property
Need to change cohort_dose property to type = string to facilitate upload of inconsistent data