### PR TITLE
Fix #65 - pre-align

### DIFF
--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -406,7 +406,7 @@ Relationships:
         Dst: study_arm
       - Src: case
         Dst: study_arm
-        Mul: one_to_one
+        Mul: many_to_one
     Props: null
   of_study:
     Mul: many_to_many


### PR DESCRIPTION
Fixed the cardinality applied to the newly-added relationship from case to study_arm at line 409

It was incorrectly defined as being one_to_one; it should be many_to_one (Cases to Study Arm)