### PR TITLE
Fix #70 Add support for study-level Publications

### DIFF
--- a/model-desc/icdc-model-props.yml
+++ b/model-desc/icdc-model-props.yml
@@ -797,6 +797,29 @@ PropDefinitions:
       the UI
     Src: curated
     Type: integer
+  # publication props
+  publication_title:
+    Desc: full title of the publication stated exactly as applied to the published work
+    Type: string
+    Req: true
+  authorship:
+    Desc: list of authors for the cited work, i.e. for publications with no more than three authors, authorship quoted in full; for publications with more than three authors, authorship abbreviated to first author et al
+    Type: string
+    Req: true
+  year_of_publication:
+    Desc: year in which the cited work was published
+    Type: number
+    Req: true
+  journal_citation:
+    Desc: name of the journal in which the cited work was published, inclusive of the citation itself in terms fo jouranl volume number, part number where applicable and page numbers
+    Type: string
+    Req: true
+  digital_object_id:
+    Desc: digital object identifier for the cited work by which it can be permanently identified and linked on the web
+    Type: string
+  pubmed_id:
+    Desc: unique numerical identifier assigned to the cited work by PubMed
+    Type: number
   # registration props
   registration_origin:
     Desc: the entity with which a subject registration ID is associated, for example an ICDC study, the CCOGC biobank from which samples for a study subject were acquired, etc.

--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -271,6 +271,15 @@ Nodes:
       - phase_pe
       - assessment_timepoint
       - crf_id
+  publication:
+    Category: administrative
+    Props:
+      - publication_title
+      - authorship
+      - year_of_publication
+      - journal_citation
+      - digital_object_id
+      - pubmed_id
   vital_signs:
     Category: clinical_trial
     Props:
@@ -434,6 +443,9 @@ Relationships:
         Dst: study
         Mul: many_to_one
       - Src: image_collection
+        Dst: study
+        Mul: many_to_one
+      - Src: publication
         Dst: study
         Mul: many_to_one
     Props: null


### PR DESCRIPTION
Add publication node

Add relationship from publication to study, many-to-one

Add properties for:
- publication_title
 - authorship
 - year_of_publication
 - journal_citation
 - digital_object_id
 - pubmed_id