### PR TITLE
Fix #77 Update model in terms of assorted data-driven changes

### DIFF
--- a/model-desc/icdc-model-props.yml
+++ b/model-desc/icdc-model-props.yml
@@ -266,8 +266,8 @@ PropDefinitions:
       - Progressive Disease
       - Not Determined 
       # included to accommodate situations either where the study in question 
-      # does not assess the effects of any therpeutic intervention or where 
-      # the response to therpeutic intervention could not be determined
+      # does not assess the effects of any therapeutic intervention or where 
+      # the response to therapeutic intervention could not be determined
       - Not Applicable 
       # included to accommodate situations in which healthy control subjects
       # are included within a study that does assess the effects of a
@@ -459,6 +459,7 @@ PropDefinitions:
       - Index File
       - Array CGH Analysis File # required for the MGC01 study
       - Variant Call File # for raw .vcf files
+      - Mutation Annotation File # for annotated .maf files
       - Variant Report # for reports detailing validated variants
       - Data Analysis Whitepaper # for any document detailing a data analysis pipeline and/or methodology
     Req: true
@@ -555,6 +556,8 @@ PropDefinitions:
         - MRI
         - PET
         - X-ray
+        - Optical
+        - Ultrasound
     Req: true
   image_collection_url:
     Desc: external url via which the image collection can be accessed and viewed

--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -412,7 +412,10 @@ Relationships:
         Dst: case
       - Src: sample
         Dst: case
-    # to accommodate a Sample being directly associated with a Case, rather than being only indirectly associated with a Case through a Visit etc.
+    # to accommodate a Sample being directly associated with a Case, rather than being only indirectly associated with a Case through a Visit, etc.
+      - Src: file
+        Dst: case
+    # to accommodate a File being directly associated with a Case, rather than being only indirectly associated with a Case through a Sample or Diagnosis
       - Src: visit
         Dst: case
     # to accommodate situations in which a Visit cannot be unambiguously associated with a treatment Cycle


### PR DESCRIPTION
Updated the model in terms of assorted minor changes dictated by data evolution. Specifically:

Added a many to one relationship from file to case, to support the vcf files for the GLIOMA01 study being associated with cases rather than samples

Added "Mutation Annotation File" to the list of acceptable values for the file: file_type property, to accommodate the MAF files generated by the GLIOMA01 study

Added "Ultrasound" and "Optical" to the list of acceptable values for the image_collection: image_type property

Corrected two horrible typos in comments pertaining to acceptable values for the diagnosis: best_response property