### PR TITLE
Fix #106 Add "Key" properties missing from the model.yml file

### DIFF
--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -172,6 +172,7 @@ Nodes:
     Props: 
       - visit_date
       - visit_number
+      - visit_id
   principal_investigator:
     Desc: The Principal Investigator node contains properties which identify the principal investigator(s) responsible for any given study/trial. A study/trial may have one or more principal investigators, and any given individual may be listed as a principal investigator on more than one study/trial.
     Tags:
@@ -206,6 +207,7 @@ Nodes:
       - follow_up_data
       - concurrent_disease
       - concurrent_disease_type
+      - diagnosis_id
   enrollment:
     Desc: The Enrollment node is comprised of properties which document when and where a patient/subject/donor was enrolled onto a study/trial.
     Tags:
@@ -223,6 +225,7 @@ Nodes:
       - veterinary_medical_center
       #- cohort_description
       - patient_subgroup
+      - enrollment_id
   prior_therapy:
     Desc: Properties within the Prior Therapy node detail therapies received by the patient/subject/donor prior to being enrolled in the study/trial in question. Clinical trials will typically capture more of this information than will cross-sectional and/or mechanistic studies.
     Tags:


### PR DESCRIPTION
Added the following properties to the icdc-model.yml model definition file:

diagnosis: diagnosis_id
enrollment: enrollment_id
visit: visit_id

Each was correctly added to and defined within the icdc-model-props.yml file, and identified as a "Key" property, but mistakenly not added to the icdc-model.yml file at the same time.