### PR TITLE
Fix #131 Update data model per ORGANOIDS01 and UC01 - extra terms

### DIFF
--- a/model-desc/icdc-model-props.yml
+++ b/model-desc/icdc-model-props.yml
@@ -49,9 +49,10 @@ PropDefinitions:
       - "3" # Severe
       - "4" # Life-threatening
       - "5" # Death
+      - Unknown # accommodates situations where an adverse event is described in detail but somehow not assigned any grade
     Req: 'Yes'
   adverse_event_grade_description: 
-    Desc: The grade of any given adverse event, reported in the form of a single descriptive term corresponding to one of the five enumerated grades defined by as defined by the Veterinary Comparative Oncology Group's Common Terminology Criteria for Adverse Events (VCOG-CTCAE). Although enumerated grades are standard terms for the reporting of adverse event, the narrative form of adverse event grades will be useful to users not already familiar with adverse event grading.
+    Desc: The grade of any given adverse event, reported in the form of a single descriptive term corresponding to one of the five enumerated grades defined by as defined by the Veterinary Comparative Oncology Group's Common Terminology Criteria for Adverse Events (VCOG-CTCAE). Although numerical values for grade are standard terms for the reporting of adverse events, the narrative form of adverse event grades will be useful to users not already familiar with adverse event grading.
     Src: Data Owner(s)
     Enum:
       - Mild
@@ -59,13 +60,14 @@ PropDefinitions:
       - Severe
       - Life-threatening
       - Death
+      - Unknown # accommodates situations where an adverse event is described in detail but somehow not assigned any grade
     Req: Preferred  
   adverse_event_agent_name:
     Desc: The name of any investigational new drug being administered at the time of any given adverse event being observed.
     Src: Data Owner(s)
     Type: string # changing this to string at least temporarily
       #- http://localhost/terms/domain/agent_name
-    Req: 'Yes'
+    Req: 'No'
   adverse_event_agent_dose:
     Desc: The corresponding dose of any investigational new drug being administered at the time of any given adverse event being observed.
     Src: Data Owner(s)
@@ -73,16 +75,17 @@ PropDefinitions:
       #units:
         #- mg/kg # there's no way we can specify all of the possible dosage rates - they vary wildly
       #value_type: number
-    Req: 'Yes'
+    Req: 'No'
   attribution_to_research:
     Desc: A qualitative indication as to whether any given adverse event is likely, possibly, probably or definitely caused by the clinical trial/research environment in general, or is unrelated to it.
     Src: Data Owner(s)
     Enum:
       - Unrelated # the adverse event is clearly not related to the research/clinical enviroment
       - Unlikely  # the adverse event is doubtfully related to the research/clinical enviroment
-      - Possible  # the adverse event may be not related to the research/clinical enviroment
+      - Possible  # the adverse event may be related to the research/clinical enviroment
       - Probable  # the adverse event is likely related to the research/clinical enviroment
       - Definite  # the adverse event is clearly related to the research/clinical enviroment
+      - Undefined # the adverse event cannot be assigned any of the five definitive attribution probabilities with sufficient confidence
     Req: 'Yes'
   attribution_to_ind:
     Desc: A qualitative indication as to whether any given adverse event is likely, possibly, probably or definitely caused by any investigational new drugs being administered as part of the clinical trial, or is unrelated to it.
@@ -93,7 +96,7 @@ PropDefinitions:
       - Possible
       - Probable
       - Definite
-      - Not Applicable #needed to accommodate clinical trials which don't assess the effects of an investigational new drug
+      - Not Applicable # needed to accommodate clinical trials which don't assess the effects of an investigational new drug
     Req: 'Yes'
   attribution_to_disease:
     Desc: A qualitative indication as to whether any given adverse event is likely, possibly, probably or definitely caused by the disease for which the patient/subject is being treated, or is unrelated to it.
@@ -104,6 +107,7 @@ PropDefinitions:
       - Possible
       - Probable
       - Definite
+      - Undefined # the adverse event cannot be assigned any of the five definitive attribution probabilities with sufficient confidence
     Req: 'Yes'
   attribution_to_commercial:
     Desc: A qualitative indication as to whether any given adverse event is likely, possibly, probably or definitely caused by a commercially-available, FDA-approved therapeutic agent, used within the confines of the clinical trial either for its FDA-approved indication or in an off-label manner, but not as the investigational new drug or part of the investigational new therapy, versus the adverse event in question being unrelated to it.
@@ -114,7 +118,7 @@ PropDefinitions:
       - Possible
       - Probable
       - Definite
-      - Not Applicable #needed to accommodate clinical trials which don't directly assess the effects of any commercially available therapeutic agent or use such agents as part of the therapy
+      - Not Applicable # needed to accommodate clinical trials which don't directly assess the effects of any commercially available therapeutic agent or use such agents as part of the therapy
     Req: 'Yes'
   attribution_to_other:
     Desc: A qualitative indication as to whether any given adverse event is likely, possibly, probably or definitely caused by some other factor(s), as described by the other_attribution_description property, or is unrelated to such other factors.
@@ -125,18 +129,20 @@ PropDefinitions:
       - Possible
       - Probable
       - Definite
+      - Undefined # the adverse event cannot be assigned any of the five definitive attribution probabilities with sufficient confidence
     Req: 'Yes'
   other_attribution_description:
     Desc: A description of any other factor or factors to which any given adverse event has been attributed. Where an adverse event is attributed to factors other than the standard factors of research, disease, IND or commercial, a description of the other factor(s) to which the adverse event was attributed is required.
     Src: Data Owner(s)
     Type: string
-    Req: 'No' #although not strictly required, if attribution_to_other is anything other than unlikely, the other attribution must be stated
+    Req: 'No' # although not strictly required, if attribution_to_other is anything other than unlikely, the other attribution must be stated
   dose_limiting_toxicity:
     Desc: An indication as to whether any given adverse event observed during the clinical trial is indicative of the dose of the therapeutic agent under test being limiting in terms of its toxicity.
     Src: Data Owner(s)
     Enum:
       - 'Yes'
       - 'No'
+      - Not Applicable # accommodates situations where an adverse event is not atrributed to any therapeutic agent and cannot therefore be limiting in terms of dosage
     Req: 'Yes'
   unexpected_adverse_event:
     Desc: An indication as to whether any given adverse event observed during the clinical trial is completely unanticipated and therefore considered novel.
@@ -144,6 +150,7 @@ PropDefinitions:
     Enum:
       - 'Yes'
       - 'No'
+      - Undefined # accommodates situations where there is any ambiguity in terms of an adverse event being expected or not
     Req: 'Yes'
   # agent props
   document_number:
@@ -741,6 +748,7 @@ PropDefinitions:
       - T Cell Lymphoma
       - Thyroid Cancer
       - Unknown
+      - Urothelial Carcinoma
       # these represent the de facto acceptable values, i.e. the values that our data submitters have used thus far
     Req: 'Yes'
     Tags:
@@ -813,6 +821,7 @@ PropDefinitions:
       - Unknown
       - Urethra, Prostate
       - Urinary Tract
+      - Urogenital Tract
       # these represent the de facto acceptable values, i.e. the values that our data submitters have used thus far
     Req: 'Yes'
     Tags:
@@ -1568,6 +1577,7 @@ PropDefinitions:
       - Cutis
       - Distal Urethra
       - Femur
+      - Genitourinary Tract
       - Hemispheric
       - Humerus
       - Kidney
@@ -1598,6 +1608,7 @@ PropDefinitions:
       - Urethra
       - Urethra Mid-distal
       - Urinary Tract
+      - Urogenital Tract
       # these represent the de facto acceptable values, i.e. the values that our data submitters have used thus far
     Req: 'Yes'
     Tags:
@@ -1666,14 +1677,14 @@ PropDefinitions:
       - Normal Tissue
       - Organoid (ASC-derived)
       - Patient-Derived Organoid
-      - Patient-Derived Organoid (Urine-derived)
+      - Patient-Derived Organoid (urine-derived)
       - PDO
       - Primary Malignant Tumor Tissue
       - Urine Sediment
       - Tumor Cell Line
       - Tumor Cell Line (metastasis-derived)
       - Tumoroid
-      - Tumoroid (Urine-derived)
+      - Tumoroid (urine-derived)
       - Whole Blood
       # these represent the de facto acceptable values, i.e. the values to which we have thus far aligned submitted data
     Req: 'Yes'

--- a/model-desc/icdc-model-props.yml
+++ b/model-desc/icdc-model-props.yml
@@ -52,7 +52,7 @@ PropDefinitions:
       - Unknown # accommodates situations where an adverse event is described in detail but somehow not assigned any grade
     Req: 'Yes'
   adverse_event_grade_description: 
-    Desc: The grade of any given adverse event, reported in the form of a single descriptive term corresponding to one of the five enumerated grades defined by as defined by the Veterinary Comparative Oncology Group's Common Terminology Criteria for Adverse Events (VCOG-CTCAE). Although numerical values for grade are standard terms for the reporting of adverse events, the narrative form of adverse event grades will be useful to users not already familiar with adverse event grading.
+    Desc: The grade of any given adverse event, reported in the form of a single descriptive term corresponding to one of the five enumerated grades as defined by the Veterinary Comparative Oncology Group's Common Terminology Criteria for Adverse Events (VCOG-CTCAE). Although numerical values for grade are standard terms for the reporting of adverse events, the narrative form of adverse event grades will be useful to users not already familiar with adverse event grading.
     Src: Data Owner(s)
     Enum:
       - Mild


### PR DESCRIPTION
Additional minor revisions to the controlled vocabularies for disease_term, primary_disease_site

Assorted revisions within adverse_event to make the node more flexible in terms of the data that it will accept