### PR TITLE
Add new file to support content and content order for download and ex…

### DIFF
--- a/model-desc/icdc-manifest-props.yml
+++ b/model-desc/icdc-manifest-props.yml
@@ -3,20 +3,18 @@
 # Lower case names are labels for the entities
 
 
-Nodes:
-# These properties are required by the CGC 
+Static_Props:
+# The first 4 properties included in a file manifest will not change and are listed in this block.
+# These properties are required by the CGC
   file:
-    Export:
-      - file_name
-      - drs_uri
-# This property is ordered for context
-  study:
-    Export:
-      - clinical_study_designation
-# This property is ordered for context
+    - file_name
+    - drs_uri
+# These properties are ordered for context
+  study: 
+    - clinical_study_designation
   case:
-    Export:
-      - case_id
+    - case_id
+Nodes:
   file:
     Export:
       - file_type

--- a/model-desc/icdc-manifest-props.yml
+++ b/model-desc/icdc-manifest-props.yml
@@ -1,22 +1,14 @@
 # ICDC nodes and props for the file manifest
 # Title case names are "reserved" (meaningful to the parser)
 # Lower case names are labels for the entities
-
-
-Static_Props:
-# The first 4 properties included in a file manifest will not change and are listed in this block.
-# These properties are required by the CGC
-  file:
-    - file_name
-    - drs_uri
-# These properties are ordered for context
-  study: 
-    - clinical_study_designation
-  case:
-    - case_id
+# The first 4 properties listed in the File Manifest are designated in StaticProps. The file properties are required by the CGC and the others are designated for context. These will not change and do not need to be read dynamically.
+   
 Nodes:
   file:
-    Export:
+    StaticProps:
+      - file_name
+      - drs_uri
+    ExportProps:
       - file_type
       - file_description
       - file_format
@@ -24,7 +16,12 @@ Nodes:
       - md5sum
       - uuid
       - file_location
+  case:
+    StaticProps:
+      - case_id
   study:
+    StaticProps:
+      - clinical_study_designation
     Export:
       - clinical_study_designation
       - case_id
@@ -75,6 +72,6 @@ Nodes:
       - percentage_tumor
       - sample_preservation
 
-    
-  
- 
+
+
+      

--- a/model-desc/icdc-manifest-props.yml
+++ b/model-desc/icdc-manifest-props.yml
@@ -1,0 +1,82 @@
+# ICDC nodes and props for the file manifest
+# Title case names are "reserved" (meaningful to the parser)
+# Lower case names are labels for the entities
+
+
+Nodes:
+# These properties are required by the CGC 
+  file:
+    Export:
+      - file_name
+      - drs_uri
+# This property is ordered for context
+  study:
+    Export:
+      - clinical_study_designation
+# This property is ordered for context
+  case:
+    Export:
+      - case_id
+  file:
+    Export:
+      - file_type
+      - file_description
+      - file_format
+      - file_size
+      - md5sum
+      - uuid
+      - file_location
+  study:
+    Export:
+      - clinical_study_designation
+      - case_id
+      - patient_id
+      - patient_first_name
+      - cohort_description
+      - cohort_dose
+      - cohort_id
+  demographic:
+    Export:
+      - demographic_id
+      - breed
+      - additional_breed_detail
+      - patient_age_at_enrollment
+      - date_of_birth
+      - sex
+      - weight
+      - neutered_indicator
+      - diagnosis_id
+      - disease_term
+      - stage_of_disease
+      - histology_cytopathology
+      - date_of_histology_confirmation
+      - histological_grade
+      - best_response
+      - pathology_report
+      - treatment_data
+      - follow_up_data
+      - concurrent_disease
+      - concurrent_disease_type
+  sample:
+    Export:
+      - sample_id
+      - sample_site
+      - physical_sample_type
+      - general_sample_pathology
+      - tumor_sample_origin
+      - summarized_sample_type
+      - molecular_subtype
+      - specific_sample_pathology
+      - date_of_sample_collection
+      - sample_chronology
+      - necropsy_sample
+      - tumor_grade
+      - length_of_tumor
+      - width_of_tumor
+      - volume_of_tumor
+      - percentage_tumor
+      - sample_preservation
+
+    
+  
+ 

--- a/model-desc/icdc-manifest-props.yml
+++ b/model-desc/icdc-manifest-props.yml
@@ -22,7 +22,7 @@ Nodes:
   study:
     StaticProps:
       - clinical_study_designation
-    Export:
+    ExportProps:
       - clinical_study_designation
       - case_id
       - patient_id
@@ -31,7 +31,7 @@ Nodes:
       - cohort_dose
       - cohort_id
   demographic:
-    Export:
+    ExportProps:
       - demographic_id
       - breed
       - additional_breed_detail
@@ -53,7 +53,7 @@ Nodes:
       - concurrent_disease
       - concurrent_disease_type
   sample:
-    Export:
+    ExportProps:
       - sample_id
       - sample_site
       - physical_sample_type
@@ -74,4 +74,3 @@ Nodes:
 
 
 
-      


### PR DESCRIPTION
This new file will dictate the contents and the order of the contents for the exportable (to the CGC) and downloadable (within the ICDC) file manifest. The first two properties are required by the Cancer Genomics Cloud. The third and fourth properties appear in a deliberate order for context. The order by which the rest of the properties appear in this file was thoughtfully curated per https://tracker.nci.nih.gov/browse/ICDC-3491