### PR TITLE
Remove props from ExportProps block

### DIFF
--- a/model-desc/icdc-manifest-props.yml
+++ b/model-desc/icdc-manifest-props.yml
@@ -23,8 +23,6 @@ Nodes:
     StaticProps:
       - clinical_study_designation
     ExportProps:
-      - clinical_study_designation
-      - case_id
       - patient_id
       - patient_first_name
       - cohort_description

--- a/model-desc/icdc-model-props.yml
+++ b/model-desc/icdc-model-props.yml
@@ -6,6 +6,12 @@ PropDefinitions:
     Tags:
       Template: 'No'
   # adverse_event props
+  adverse_event_id:
+    Desc: A globally unique identifier via which adverse event records can be differentiated from one another across studies/trials. Specifically the value of case_id concatenated with the value of adverse_event_term. <br>This property is used as the key to identify the correct adverse event records during data upates.
+    Src: Data Owner(s)
+    Type: string
+    Req: true
+    Key: true
   day_in_cycle:
     Desc: Numerically, the day in the treatment cycle upon which any given adverse event was first observed, where Day 1 is the first day of the treatment cycle within which the adverse event was observed. Some patients/subjects may undergo multiple treatment cycles, such that two or more adverse events may be observed on the same day in cycle, but actually be observed on different dates, because they occur in different treatment cycles.  
     Src: Data Owner(s)
@@ -158,102 +164,103 @@ PropDefinitions:
       - 'No'
       - Undefined # accommodates situations where there is any ambiguity in terms of an adverse event being expected or not
     Req: 'Yes'
-  # agent props
-  document_number:
-    Desc: S/N of the executed CRF
-    Src: ALL
-    Type:
-      pattern: "^R[0-9]+$\n"
-  medication:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type:
-      - http://localhost/terms/domain/medication
-  # agent_administration props
-  comment:
-    Desc: generic comment
-    Type: string
-  date_of_missed_dose:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: datetime
+  # # agent props **proposing deprecation or removal of all props in this node as it contains no data across ingested studies as of 7/16/24
+  # document_number:
+  #   Desc: S/N of the executed CRF
+  #   Src: ALL
+  #   Type:
+  #     pattern: "^R[0-9]+$\n"
+  # medication:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type:
+  #     - http://localhost/terms/domain/medication
+  # agent_administration props **proposing deprecation or removal of all props in this node as it contains no data across ingested studies as of 7/16/24
+  # comment:
+  #   Desc: generic comment
+  #   Type: string
+  # date_of_missed_dose:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: datetime
   # document_number also included in agent_administration
-  dose_level:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type:
-      units:
-        - mg/kg
-      value_type: number
-  dose_units_of_measure:
-    Deprecated: true
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: string
+  # dose_level:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type:
+  #     units:
+  #       - mg/kg
+  #     value_type: number
+  # dose_units_of_measure:
+  #   Deprecated: true
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: string
   # medication also included in agent_administration
-  medication_actual_dose:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type:
-      units:
-        - mg/kg
-      value_type: number
-  medication_actual_units_of_measure:
-    Deprecated: true
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: string
-  medication_course_number:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: string
-  medication_duration:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type:
-      units:
-        - days
-        - hr
-        - min
-      value_type: number
-  medication_lot_number:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: string
-  medication_missed_dose:
-    Desc: Q.- form has "medication"
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type:
-      - http://localhost/terms/domain/agent_name
-  medication_units_of_measure:
-    Deprecated: true
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: string
-  medication_vial_id:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: string
-  missed_dose_amount:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type:
-      units:
-        - mg/kg
-      value_type: number
-  missed_dose_units_of_measure:
-    Deprecated: true
-    Desc: Q.- form has "dose uom_ful"
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: string
-  phase:
-    Desc: Where should this live?/What is?
-    Src: COURSE INIT/CINIT/1
-    Type: TBD
-  route_of_administration:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type:
-      - http://localhost/terms/domain/route_of_administration
-  start_time:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: datetime
-  stop_time:
-    Src: STUDY_MED_ADMIN/SDAD/1
-    Type: datetime
+  # medication_actual_dose:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type:
+  #     units:
+  #       - mg/kg
+  #     value_type: number
+  # medication_actual_units_of_measure:
+  #   Deprecated: true
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: string
+  # medication_course_number:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: string
+  # medication_duration:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type:
+  #     units:
+  #       - days
+  #       - hr
+  #       - min
+  #     value_type: number
+  # medication_lot_number:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: string
+  # medication_missed_dose:
+  #   Desc: Q.- form has "medication"
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type:
+  #     - http://localhost/terms/domain/agent_name
+  # medication_units_of_measure:
+  #   Deprecated: true
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: string
+  # medication_vial_id:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: string
+  # missed_dose_amount:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type:
+  #     units:
+  #       - mg/kg
+  #     value_type: number
+  # missed_dose_units_of_measure:
+  #   Deprecated: true
+  #   Desc: Q.- form has "dose uom_ful"
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: string
+  # phase:
+  #   Desc: Where should this live?/What is?
+  #   Src: COURSE INIT/CINIT/1
+  #   Type: TBD
+  # route_of_administration:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type:
+  #     - http://localhost/terms/domain/route_of_administration
+  # start_time:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: datetime
+  # stop_time:
+  #   Src: STUDY_MED_ADMIN/SDAD/1
+  #   Type: datetime
   # biospecimen_source props
   biospecimen_repository_acronym:
-    Desc: The name of the biobank or tissue repository from which or to which samples for any given patient/subject/donor were acquired or submitted, expressed in the form of an acronym.
+    Desc: The name of the biobank or tissue repository from which or to which samples for any given patient/subject/donor were acquired or submitted, expressed in the form of an acronym. <br>This property is used as the key v to identify the correct biospecimen repository records during data updates.
     Src: Internally-curated
     Type: string
     Req: 'Yes'
+    Key: true
     Tags:
        Labeled: Biobank
   biospecimen_repository_full_name:
@@ -311,11 +318,17 @@ PropDefinitions:
        Labeled: Cohorts
   cohort_id:
     Desc: A unique identifier via which cohorts can be differentiated from one another across studies/trials. <br>This property is used as the key via which cases can be associated with the appropriate cohort during data loading, and to identify the correct records during data updates.
-    Src: Internally-curated
+    Src: Data Owner(s)
     Type: string
     Req: 'Yes'
     Key: true
   # cycle props
+  cycle_id:
+    Desc: A globally unique identifier for each therapy cycle administered to a patient/subject; specifically the value of case_id concatenated with the value of cycle_number. <br>This property is used as the key via which child records, e.g. visit records, can be associated with the appropriate cycle during data loading, and to identify the correct cycle records during data upates.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+    Key: true 
   cycle_number:
     Desc: For a patient/subject/donor enrolled in a clinical trial evaluating the effects of therapy administered in multiple cycles, the number of the treatment cycle during which visits occurred such that therapy could be administered and/or clinical observations could be made, with cycles numbered according to their chronological order.
     Src: Data Owner(s)
@@ -632,7 +645,7 @@ PropDefinitions:
     Type: datetime
     Req: 'No'
   demographic_id:
-    Desc: A unique identifier of each demographic record, used to identify the correct demographic records during data updates. The value of this property will generally be the same as the value of the case_id property.
+    Desc: A unique identifier of each demographic record, used to identify the correct demographic records during data updates. <br>The value of this property will generally be the same as the value of the case_id property. <br> This property is used as the key to identify the correct demographic records during data updates.
     Src: Data Owner(s)
     Type: string
     Req: 'Yes'
@@ -894,6 +907,12 @@ PropDefinitions:
     Tags:
        Labeled: Treatment Data Available
   # disease_extent props
+  disease_extent_id:
+    Desc: A globally unique identifier of each evaluation of disease extent for a subject/patient/donor; specifically the value of case_id concatenated with the value of evaluation_code. <br>This property is used as the key to identify the correct disease extent records during data updates.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+    Key: true
   date_of_evaluation:
     Desc: The date upon which the extent of disease evaluation was conducted.
     Src: Data Owner(s)
@@ -918,7 +937,8 @@ PropDefinitions:
     Desc: An arbitrary numerical designation for each lesion subject to evaluation, by which that lesion can be unambiguously identified.
     Src: Data Owner(s)
     Type: Integer
-    Req: 'No'
+    Req: 'Yes'
+    Key: true
   lesion_site:
     Desc: The overall anatomical location of the lesion being assessed in terms of the organ or organ system in which it is located. For example, lung, lymph node, etc.
     Src: Data Owner(s)
@@ -1087,7 +1107,7 @@ PropDefinitions:
     Tags:
        Template: 'No'
   uuid:
-    Desc: The universally unique alpha-numeric identifier assigned to each file.
+    Desc: The universally unique alpha-numeric identifier assigned to each file. <br>This property is used as the key to identify the correct file records during data updates.
     Src: Loader-derived
     Type: string
     Req: 'Yes'
@@ -1102,115 +1122,121 @@ PropDefinitions:
     Req: 'No'
     Tags:
        Template: 'No'
-  # follow_up props
-  contact_type:
-    Desc: need vocab
-    Src: FOLLOW_UP/FLWU/1
-    Type: string
-  date_of_last_contact:
-    Src: FOLLOW_UP/FLWU/1
-    Type: datetime
+  # # follow_up props proposing deprecation or removal of props as this node does not contain any data values as of 7/16/24.
+  # contact_type:
+  #   Desc: need vocab
+  #   Src: FOLLOW_UP/FLWU/1
+  #   Type: string
+  # date_of_last_contact:
+  #   Src: FOLLOW_UP/FLWU/1
+  #   Type: datetime
   # document_number: also included in follow_up node, defined elsewhere in this document
   #  Desc: S/N of the executed CRF
   #  Src: ALL
   #  Type:
   #    pattern: "^R[0-9]+$\n"
-  explain_unknown_status:
-    Desc: free text?
-    Src: FOLLOW_UP/FLWU/1
-    Type: string
-  patient_status:
-    Desc: need vocab
-    Src: FOLLOW_UP/FLWU/1
-    Type: string
-  physical_exam_changes:
-    Desc: How described? Relative to data already stored in "physical_exam" node?
-    Src: FOLLOW_UP/FLWU/1
-    Type: TBD
-  physical_exam_performed:
-    Desc: y/n
-    Src: FOLLOW_UP/FLWU/1
-    Type: boolean
-  treatment_since_last_contact:
-    Desc: y/n
-    Src: FOLLOW_UP/FLWU/1
-    Type: boolean
-  # image collection props
-  image_collection_name:
-    Desc: The name of the image collection exactly as it appears at the location where the collection can be viewed and/or accessed.
-    Src: Internally-curated
-    Type: string
-    Req: 'Yes'
-    Tags:
-       Labeled: Collection
-  image_type_included:
-    Desc: A list of the image types included in the image collection, drawn from a list of acceptable values.
-    Src: Internally-curated
-    Type:
-      value_type: list
-      Enum:
-        - CT
-        - Histopathology
-        - MRI
-        - PET
-        - X-ray
-        - Optical
-        - Ultrasound
-    Req: 'Yes'
-    Tags:
-       Labeled: Image Types
-  image_collection_url:
-    Desc: The external url via which the image collection can be viewed and/or accessed.
-    Src: Internally-curated
-    Type: string
-    Req: 'Yes'
-  repository_name:
-    Desc: The name of the image repository within which the image collection can be found, stated in the form of the appropriate acronym.
-    Src: Internally-curated
-    Type: string
-    Req: 'Yes'
-  collection_access:
-    Desc: Indicator as to whether the image collection can be accessed via download versus being accessible only via the cloud.
-    Src: Internally-curated
-    Enum:
-      - Download
-      - Cloud
-    Req: 'Yes'
+  # explain_unknown_status:
+  #   Desc: free text?
+  #   Src: FOLLOW_UP/FLWU/1
+  #   Type: string
+  # patient_status:
+  #   Desc: need vocab
+  #   Src: FOLLOW_UP/FLWU/1
+  #   Type: string
+  # physical_exam_changes:
+  #   Desc: How described? Relative to data already stored in "physical_exam" node?
+  #   Src: FOLLOW_UP/FLWU/1
+  #   Type: TBD
+  # physical_exam_performed:
+  #   Desc: y/n
+  #   Src: FOLLOW_UP/FLWU/1
+  #   Type: boolean
+  # treatment_since_last_contact:
+  #   Desc: y/n
+  #   Src: FOLLOW_UP/FLWU/1
+  #   Type: boolean
+  # suggesting deprecation or removal of image collection props as all imgaing data will be stored and fetched through the IDC & TCIA API.
+  # image_collection_name:
+  #   Desc: The name of the image collection exactly as it appears at the location where the collection can be viewed and/or accessed.
+  #   Src: Internally-curated
+  #   Type: string
+  #   Req: 'Yes'
+  #   Tags:
+  #      Labeled: Collection
+  # image_type_included:
+  #   Desc: A list of the image types included in the image collection, drawn from a list of acceptable values.
+  #   Src: Internally-curated
+  #   Type:
+  #     value_type: list
+  #     Enum:
+  #       - CT
+  #       - Histopathology
+  #       - MRI
+  #       - PET
+  #       - X-ray
+  #       - Optical
+  #       - Ultrasound
+  #   Req: 'Yes'
+  #   Tags:
+  #      Labeled: Image Types
+  # image_collection_url:
+  #   Desc: The external url via which the image collection can be viewed and/or accessed.
+  #   Src: Internally-curated
+  #   Type: string
+  #   Req: 'Yes'
+  # repository_name:
+  #   Desc: The name of the image repository within which the image collection can be found, stated in the form of the appropriate acronym.
+  #   Src: Internally-curated
+  #   Type: string
+  #   Req: 'Yes'
+  # collection_access:
+  #   Desc: Indicator as to whether the image collection can be accessed via download versus being accessible only via the cloud.
+  #   Src: Internally-curated
+  #   Enum:
+  #     - Download
+  #     - Cloud
+  #   Req: 'Yes'
   # off_study props and
-  # off_treatment props
-  best_resp_vet_tx_tp_best_response:
-    Src: OFF_STUDY/OSSM/1
-    Type: TBD
-  best_resp_vet_tx_tp_secondary_response:
-    Src: OFF_STUDY/OSSM/1
-    Type: TBD
-  date_last_medication_administration:
-    Src: OFF_STUDY/OSSM/1
-    Type: datetime
-  date_of_best_response:
-    Src: OFF_STUDY/OSSM/1
-    Type: datetime
-  date_of_disease_progression:
-    Src: OFF_STUDY/OSSM/1
-    Type: datetime
-  date_off_study:
-    Src: OFF_STUDY/OSSM/1
-    Type: datetime
-  date_off_treatment:
-    Src: OFF_STUDY/OSSM/1
-    Type: datetime
+  # off_treatment props proposing deprecation or removal as these nodes do not contain any data values across all ingested studies as of 7/16/24
+  # best_resp_vet_tx_tp_best_response:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: TBD
+  # best_resp_vet_tx_tp_secondary_response:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: TBD
+  # date_last_medication_administration:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: datetime
+  # date_of_best_response:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: datetime
+  # date_of_disease_progression:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: datetime
+  # date_off_study:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: datetime
+  # date_off_treatment:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: datetime
   # document_number: also included in off_study node, defined elsewhere in this document
   #   Desc: S/N of the executed CRF
   #   Src: ALL
   #   Type:
   #     pattern: "^R[0-9]+$\n"
-  reason_off_study:
-    Src: OFF_STUDY/OSSM/1
-    Type: string
-  reason_off_treatment:
-    Src: OFF_STUDY/OSSM/1
-    Type: string
+  # reason_off_study:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: string
+  # reason_off_treatment:
+  #   Src: OFF_STUDY/OSSM/1
+  #   Type: string
   # physical_exam props
+  physical_exam_id: 
+    Desc: A globally unique identifier of each physical exam record; specifically the value of case_id concatenated with the value of date_of_examination, the date upon which the physical exam was conducted. <br>This property is used as the key to identify the correct physical exam records during data updates.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+    Key: true
   assessment_timepoint:
     Desc: An indication as to the timing of the visit during which the physical examination was conducted. This could be a visit number indicative of physical examination's chronology, a narrative statement/description of the vist, or a combination of both. 
     Src: Data Owner(s)
@@ -1252,6 +1278,8 @@ PropDefinitions:
     Src: Data Owner(s)
     Type: TBD
   # principal_investigator props
+  pi_id: 
+    Desc: A globally unique identifier via which principle investigator can be differentiated across studies; specifically the value of study_id concatenated with the value of pi_last_name, <br>This property is used as the key via which child records, e.g. cohort records, can be associated with the appropriate principle investigator, and to identify the correct principle investigator records during data updates.
   pi_first_name:
     Desc: The first or given name of each principal investigator of the study/trial.
     Src: Data Owner(s)
@@ -1274,6 +1302,12 @@ PropDefinitions:
     Tags:
        Labeled: Principal Investigators
   # prior_surgery props
+  prior_surgery_id:
+    Desc: A globally unique identifier of each prior surgery record; <br>This property is used as the key to identify the correct prior surgery records during data updates.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+    Key: true
   anatomical_site_of_surgery:
     Desc: The anatomical location at which the prior surgery in question occurred. 
     Src: Data Owner(s)
@@ -1306,6 +1340,12 @@ PropDefinitions:
     Type: TBD
     Req: 'No'
   # prior_therapy props
+  prior_therapy_id:
+    Desc: A globally unique identifier of each prior therapy record; <br>This property is used as the key to identify the correct prior therapy records during data updates.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+    Key: true
   agent_name:
     Src: PRIOR_THRPY_SUPP/PTHR/1
     Type:
@@ -1395,7 +1435,7 @@ PropDefinitions:
     Type: TBD
   # program props
   program_acronym:
-    Desc: The name of the program under which related studies will be grouped, expressed in the form of the acronym by which it will identified within the UI. <br>This property is used as the key via which study records can be associated with the appropriate program during data loading, and to identify the correct records during data updates.
+    Desc: The name of the program under which related studies will be grouped, expressed in the form of the acronym by which it will identified within the UI. <br>This property is used as the key via which child records, e.g. study records can be associated with the appropriate program during data loading, and to identify the correct records during data updates.
     Src: Internally-curated
     Type: string
     Req: 'Yes'
@@ -1429,11 +1469,10 @@ PropDefinitions:
     Req: 'No'
   # publication props
   publication_title:
-    Desc: The full title of the publication stated exactly as it appears on the published work. <br>This property is used as the key via which to identify the correct records during data updates.
+    Desc: The full title of the publication stated exactly as it appears on the published work. 
     Src: Data Owner(s)
     Type: string
     Req: 'Yes'
-    Key: true
   authorship:
     Desc: A list of authors for the cited work. More specifically, for publications with no more than three authors, authorship quoted in full; for publications with more than three authors, authorship abbreviated to first author et al.
     Src: Data Owner(s)
@@ -1456,10 +1495,11 @@ PropDefinitions:
     Tags:
        Labeled: Journal
   digital_object_id:
-    Desc: Where applicable, the digital object identifier for the cited work, by which it can be permanently identified, and linked to via the internet. <br>Values of this property must contain only the alphanumeric string of the digital object identifier itself, exclusive of any prefix such as "DOI:", such that values can be correctly interpreted and displayed as hyperlinks within the application.
+    Desc: Where applicable, the digital object identifier for the cited work, by which it can be permanently identified, and linked to via the internet. <br>Values of this property must contain only the alphanumeric string of the digital object identifier itself, exclusive of any prefix such as "DOI:", such that values can be correctly interpreted and displayed as hyperlinks within the application. <br>This property is used as the key via which to identify the correct publication records during data updates.
     Src: Data Owner(s)
     Type: string
-    Req: Preferred
+    Req: 'Yes'
+    Key: true
     Tags:
        Labeled: DOI
   pubmed_id:
@@ -1476,10 +1516,11 @@ PropDefinitions:
     Type: string
     Req: 'Yes'
   registration_id:
-    Desc: Any ID used by a data submitter to identify a patient/subject/donor, either locally or globally.
+    Desc: A globally unique identifier to describe a patient/donor/subject; specifically the value of case_id. <br>This property is used as the key to identify the registration records during data updates.  
     Src: Data Owner(s)
     Type: string
     Req: 'Yes'
+    Key: true
   #is_primary_id:
    #Desc: Indicator as to whether the ID in question was also independently captured as patient_id and therefore used to create case_id; for each study/trial participant subject, one, and only one, registration ID must be flagged as being a primary ID
     #Type:
@@ -1861,10 +1902,11 @@ PropDefinitions:
     Type: string
     Req: 'No'
   site_short_name:
-    Desc: The widely-accepted acronym for the institution at which the patient/subject/donor was enrolled into the study/trial, and then treated under the appropriate veterinary medicine program.
+    Desc: The widely-accepted acronym for the institution at which the patient/subject/donor was enrolled into the study/trial, and then treated under the appropriate veterinary medicine program. <br>This property is used as the key  to identify the correct records during data updates.
     Src: Data Owner(s)
     Type: string
-    Req: 'No'
+    Req: 'Yes'
+    Key: true
     Tags:
        Labeled: Study Site
   veterinary_medical_center:
@@ -1880,7 +1922,7 @@ PropDefinitions:
     Req: 'No'
   visit_id:
     Desc: A globally unique identifier of each visit record; specifically the value of case_id concatenated with the value of visit_date, the date upon which the visit occurred. <br>This property is used as the key via which child records, e.g. physical examination records, can be associated with the appropriate visit, and to identify the correct visit records during data updates.
-    Src: Data-derived
+    Src: Data Owner(s)
     Type: string
     Req: 'Yes'
     Key: true
@@ -1892,6 +1934,12 @@ PropDefinitions:
   # assessment_timepoint: also included in vital_signs node, defined elsewhere
   #   Src: PHYSICAL_EXAM/PE/1
   #   Type: integer
+  vital_signs_id:
+    Desc: A globally unique identifier of each vital signs record collected during a scheduled visit; specifically the value of case_id concatenated with the value of date_of_vital_signs, the date upon which the vital signs evaluation in question was conducted. <br>This property is used as the key to identify the correct vital signs records during data updates.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+    Key: true
   body_surface_area:
     Desc: The body surface area of the patient/subject/donor at the time of the vital signs evaluation, expressed in square meters.
     Src: Data Owner(s)
@@ -1963,3 +2011,32 @@ PropDefinitions:
       units:
         - mm Hg
       value_type: integer
+  # lab_exam props
+  lab_exam: 
+    Desc: Any procedure that involves testing or manipulating a sample of blood, urine, or other body substance in a laboratory setting. Tests can help determine a diagnosis, plan treatment, check to see if treatment is working, or monitor the disease over time.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+  lab_exam_id:
+    Desc: A globally unique identifier of each lab exam record; specifically the value of case_id concatenated with the value of lab_exam_date, the date upon which the lab exam occurred. <br>This property is used as the key to identify the correct lab exam records during data updates.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+    Key: true
+  lab_exam_date:
+    Desc:  The date upon which the lab exam occurred.
+    Src: Data Owner(s)
+    Type: datetime
+    Req: 'Yes'
+  # assay props
+  assay_id:
+    Desc: A globally unique identifier of each assay record; specifically the value of case_id concatenated with the value of assay type. <br>This property is used as the key to identify the correct physical exam records during data updates.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+    Key: true
+  assay_type: 
+    Desc: The type of assay being conducted.
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'

--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -63,19 +63,20 @@ Nodes:
       - arm_id # potentially needed to differentiate between arms having the same name, but which actually belong to different studies. Proactively including sooner rather than later.
       - ctep_treatment_assignment_code
       - crdc_id
-  agent:
-    Desc: The Agent node documents the name of each therapeutic agent being administered during a clinical trial. In this way, in clinical trials which assess the efficacy of combination therapies, adverse events observed during the trial can be attributed specifically to one or more of the medications being used.
-    Tags:
-      Category: clinical_trial
-      Assignment: extended
-      Class: secondary
-      Template: 'No'
-      Clinical_Data_Export: 'Yes'
-    Props:
-      - medication
-      # d/n from STUDY_MED_ADMIN/SDAD/1      
-      - document_number
-      - crdc_id
+  # proposing deprecation or removal of the agent node as it contains no data across ingested studies as of 7/16/24.
+  # agent:
+  #   Desc: The Agent node documents the name of each therapeutic agent being administered during a clinical trial. In this way, in clinical trials which assess the efficacy of combination therapies, adverse events observed during the trial can be attributed specifically to one or more of the medications being used.
+  #   Tags:
+  #     Category: clinical_trial
+  #     Assignment: extended
+  #     Class: secondary
+  #     Template: 'No'
+  #     Clinical_Data_Export: 'Yes'
+  #   Props:
+  #     - medication
+  #     # d/n from STUDY_MED_ADMIN/SDAD/1      
+  #     - document_number
+  #     - crdc_id
   cohort:
     Desc: The Cohort node contains properties required to describe the cohorts into which any given study/trial was divided. Division of a study/trial into multiple cohorts is optional and is at the discretion of the data owners, based upon the way in which the study/trial in question was structured, and how best that structure can be represented within the ICDC. Where applicable, the appropriate cohorts are defined during the study on-boarding process and then created via a specific data loading file.
     Tags:
@@ -375,20 +376,21 @@ Nodes:
       Class: secondary
       Template: 'No'
     Props: null
-  image_collection:
-    Desc: The Image Collection node is comprised of properties which describe collections of images that are associated with any given study/trial. These properties characterize such image collections in terms of the types of images they contain, where the collections are hosted, and how they can be accessed.
-    Tags:
-      Category: study
-      Assignment: core
-      Class: secondary
-      Template: 'Yes'
-    Props:
-      - image_collection_name
-      - image_type_included
-      - image_collection_url
-      - repository_name
-      - collection_access
-      - crdc_id
+  # proposing deprecation or removal the image_collection node as it contains no data across ingested studies as of 7/16/24
+  # image_collection:
+  #   Desc: The Image Collection node is comprised of properties which describe collections of images that are associated with any given study/trial. These properties characterize such image collections in terms of the types of images they contain, where the collections are hosted, and how they can be accessed.
+  #   Tags:
+  #     Category: study
+  #     Assignment: core
+  #     Class: secondary
+  #     Template: 'Yes'
+  #   Props:
+  #     - image_collection_name
+  #     - image_type_included
+  #     - image_collection_url
+  #     - repository_name
+  #     - collection_access
+  #     - crdc_id
   physical_exam:
     Desc: Properties within the Physical Exam node detail observations around the status of multiple body systems as of a patient enrolled in a clinical trial, as of that patient being examined by a veterinarian during a scheduled visit to the appropriate study site.
     Tags:
@@ -505,65 +507,68 @@ Nodes:
       - evaluation_number
       - evaluation_code
       - crdc_id
-  follow_up:
-    Desc: The Follow-up node is comprised of properties which document when a follow-up evaluation was performed, and what observations were made at each follow-up evaluation.
-    Tags:
-      Category: clinical_trial
-      Assignment: extended
-      Class: secondary
-      Template: 'Yes'
-      Clinical_Data_Export: 'Yes'
-    Props:
-      # d/n from FOLLOW_UP/FLWU/1
-      - document_number
-      - date_of_last_contact
-      - patient_status
-      - explain_unknown_status
-      - contact_type
-      - treatment_since_last_contact
-      - physical_exam_performed
-      - physical_exam_changes
-      - crdc_id
-  off_study:
-    # off_study, off_treatment -- how related? should be a dependency and normalize properties?
-    Desc: Properties within the Off Study node detail when a patient was removed from a clinical trial relative to other key dates, and the reason(s) for the patient being removed.
-    Tags:
-      Category: clinical_trial
-      Assignment: extended
-      Class: secondary
-      Template: 'Yes'
-      Clinical_Data_Export: 'Yes'
-    Props:
-      # d/n from OFF_STUDY/OSSM/1
-      - document_number
-      - date_off_study
-      - reason_off_study
-      - date_of_disease_progression
-      - date_off_treatment
-      - best_resp_vet_tx_tp_secondary_response
-      - date_last_medication_administration
-      - best_resp_vet_tx_tp_best_response
-      - date_of_best_response
-      - crdc_id
-  off_treatment:
-    Desc: Properties within the Off Treatment node detail when a clinical trial patient's treatment was curtailed relative to other key dates. Properties also detail the best response to treatment observed to that point, and the reason(s) for treatment being curtailed.
-    Tags:
-      Category: clinical_trial
-      Assignment: extended
-      Class: secondary
-      Template: 'Yes'
-      Clinical_Data_Export: 'Yes'
-    Props:
-      # d/n from OFF_TREATMENT/OTSM/1
-      - document_number
-      - date_off_treatment
-      - reason_off_treatment
-      - date_of_disease_progression
-      - best_resp_vet_tx_tp_secondary_response
-      - date_last_medication_administration
-      - best_resp_vet_tx_tp_best_response
-      - date_of_best_response
-      - crdc_id
+  # proposing deprecation or removal of the follow-up node as it contains no data across ingested studies as of 7/16/24.
+  # follow_up:
+  #   Desc: The Follow-up node is comprised of properties which document when a follow-up evaluation was performed, and what observations were made at each follow-up evaluation.
+  #   Tags:
+  #     Category: clinical_trial
+  #     Assignment: extended
+  #     Class: secondary
+  #     Template: 'Yes'
+  #     Clinical_Data_Export: 'Yes'
+  #   Props:
+  #     # d/n from FOLLOW_UP/FLWU/1
+  #     - document_number
+  #     - date_of_last_contact
+  #     - patient_status
+  #     - explain_unknown_status
+  #     - contact_type
+  #     - treatment_since_last_contact
+  #     - physical_exam_performed
+  #     - physical_exam_changes
+  #     - crdc_id
+  # proposing deprecation or removal off_study node as it contains no data across ingested studies as of 7/16/24.
+  # off_study:
+  #   # off_study, off_treatment -- how related? should be a dependency and normalize properties?
+  #   Desc: Properties within the Off Study node detail when a patient was removed from a clinical trial relative to other key dates, and the reason(s) for the patient being removed.
+  #   Tags:
+  #     Category: clinical_trial
+  #     Assignment: extended
+  #     Class: secondary
+  #     Template: 'Yes'
+  #     Clinical_Data_Export: 'Yes'
+  #   Props:
+  #     # d/n from OFF_STUDY/OSSM/1
+  #     - document_number
+  #     - date_off_study
+  #     - reason_off_study
+  #     - date_of_disease_progression
+  #     - date_off_treatment
+  #     - best_resp_vet_tx_tp_secondary_response
+  #     - date_last_medication_administration
+  #     - best_resp_vet_tx_tp_best_response
+  #     - date_of_best_response
+  #     - crdc_id
+  # proposing deprecation or removal of the off_treatment node as it contains no data across ingested studies as of 7/16/24.
+  # off_treatment:
+  #   Desc: Properties within the Off Treatment node detail when a clinical trial patient's treatment was curtailed relative to other key dates. Properties also detail the best response to treatment observed to that point, and the reason(s) for treatment being curtailed.
+  #   Tags:
+  #     Category: clinical_trial
+  #     Assignment: extended
+  #     Class: secondary
+  #     Template: 'Yes'
+  #     Clinical_Data_Export: 'Yes'
+  #   Props:
+  #     # d/n from OFF_TREATMENT/OTSM/1
+  #     - document_number
+  #     - date_off_treatment
+  #     - reason_off_treatment
+  #     - date_of_disease_progression
+  #     - best_resp_vet_tx_tp_secondary_response
+  #     - date_last_medication_administration
+  #     - best_resp_vet_tx_tp_best_response
+  #     - date_of_best_response
+  #     - crdc_id
 Relationships:
   member_of:
     Mul: many_to_one


### PR DESCRIPTION
Properties do not need to be duplicated in the ExportProps block if they are static props that are intended to be in the exported manifest.