### PR TITLE
Remove duplicate props from icdc-manifest-props.yml

### DIFF
--- a/model-desc/icdc-manifest-props.yml
+++ b/model-desc/icdc-manifest-props.yml
@@ -23,8 +23,6 @@ Nodes:
     StaticProps:
       - clinical_study_designation
     ExportProps:
-      - clinical_study_designation
-      - case_id
       - patient_id
       - patient_first_name
       - cohort_description


### PR DESCRIPTION
Props that are intended to be static for the icdc-manifest-props.yml do not need to be listed again in the ExportProps block.