### PR TITLE
ICDC-3883

### DIFF
--- a/model-desc/icdc-model-props.yml
+++ b/model-desc/icdc-model-props.yml
@@ -912,6 +912,44 @@ PropDefinitions:
     Req: Preferred
     Tags:
        Labeled: Treatment Data Available
+  # human_relevance props
+  human_relevance_record_id:
+    Desc: A unique identifier via which human relevance records can be differentiated from one another across studies/trials. Specifically, this value should be equivalent to study_code. <br>This property is used as the key to identify the correct human relevance records during data updates.
+    Src: Internally-curated
+    Type: string
+    Req: 'Yes'
+    Key: true
+  human_relevance_statement:
+    Desc: A brief (2 sentences and high-level statement of a study's relevance to human cancer research using words that are understandable to the lay public. 
+    Src: Data Owner(s)
+    Type: string
+    Req: 'Yes'
+  applicable_human_cancer:
+    Desc: The applicable human cancer relevant to the canine study.
+    Src: Data Owner(s)
+    Type: 
+      value_type: list
+      item_type: string
+    Req: 'No'
+  experimental_therapy:
+    Desc: The experimental therapy or therapies relevant to the canine study if applicable.
+    Type: 
+      value_type: list
+      item_type: string
+    Req: 'No'
+  experimental_treatment:
+    Desc: The experimental treatment or treatments relevant to the canine study if applicable.
+    Type: 
+      value_type: list
+      item_type: string
+    Req: 'No'
+
+  relevant_human_genes:
+    Desc: The human genes relevant to the canine study if applicable.
+    Type: 
+      value_type: list
+      item_type: string
+    Req: 'No'
   # disease_extent props
   date_of_evaluation:
     Desc: The date upon which the extent of disease evaluation was conducted.

--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -38,6 +38,20 @@ Nodes:
       - accession_id
       - study_disposition
       - crdc_id
+  human_relevance:
+    Desc: The Human Relevance node contains properties required to demonstrate how each study/trial offers unique opportunities for the cancer research community to gain significant insights into understanding human cancer biology (including initiation, progression, metastases), developing new treatments, mitigating toxicities, and improving outcomes for both canines and humans.
+    Tags:
+      Category: study
+      Assignment: core
+      Class: primary
+      Template: 'Yes'
+    Props:
+      - human_relevance_record_id
+      - human_relevance_statement
+      - applicable_human_cancer
+      - experimental_therapy
+      - experimental_treatment
+      - relevant_human_genes
   study_site:
     Desc: The Study Site node contains properties which identify the various sites at which any given study/trial was conducted, either in terms of where clinical trial patients were assessed and treated, or in terms of the geographical sites at which biospecimens were acquired from patients/subjects/donors for subsequent analysis.
     Tags:
@@ -627,6 +641,9 @@ Relationships:
   of_study:
     Mul: many_to_many
     Ends:
+      - Src: human_relevance
+        Dst: study
+        Mul: one_to_one
       - Src: study_site
         Dst: study
       - Src: principal_investigator


### PR DESCRIPTION
Adds the Human Relevance node and properties to the data model to highlight the pivotal role canine cancer research plays in advancing human cancer research for a general audience.