### PR TITLE
update case_id prop name in manifest YAML

### DIFF
--- a/model-desc/icdc-manifest-props.yml
+++ b/model-desc/icdc-manifest-props.yml
@@ -27,7 +27,7 @@ Nodes:
         display: "File Location"
   case:
     StaticProps:
-      - property: case_id
+      - property: case_record_id
         display: "Case ID"
   study:
     StaticProps:


### PR DESCRIPTION
- missed renaming another `case_id` to `case_record_id` property in the file manifest YAML defined in this repo (the display value is still "Case ID")