### PR TITLE
small update for ICDC-3983

### DIFF
--- a/model-desc/icdc-model-props.yml
+++ b/model-desc/icdc-model-props.yml
@@ -2033,6 +2033,17 @@ PropDefinitions:
       - Pending
       - Under Embargo
     Req: 'Yes'
+  study_accession:
+    Desc: dbGaP study accession number 
+    Req: false 
+    Type:
+      pattern: ^phs[0-9]+$
+    Term:
+    - Origin: caDSR
+      Original Source: DSS CDE
+      Code: '11524544'
+      Value: Research Activity dbGaP Accession Number Identifier
+      Version: '1.00'
   # study_arm props
   arm_id: # needs to be arm_record_id?
     Desc: A unique identifier via which study arms can be differentiated from one another across studies/trials. <br>This property is used as the key via which child records, e.g. cohort records, or in some instances individual cases, can be associated with the appropriate study arm during data loading, and to identify the correct records during data updates.
@@ -2082,7 +2093,7 @@ PropDefinitions:
     Desc: A sequence of characters used to uniquely identify, name, or characterize the presence and nature of a consent group in a study.
     Term:
       - Origin: caDSR
-        Code: 'TBD'
+        Code: '16306756'
         Value: Study Consent Group Identifier
         Version: '1'
         Tags:

--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -37,6 +37,7 @@ Nodes:
       - dates_of_conduct
       - accession_id
       - study_disposition
+      - study_accession
       - crdc_id
   consent_group:
     Desc: The Consent Group node contains properties required to characterize the consent groups defined within each study/trial. Consent groups are used to define subsets of patients/subjects/donors within a given study/trial, based upon the specific consents that those patients/subjects/donors provided at the time of enrollment.


### PR DESCRIPTION
### Summary
Adds the study_accession property to the ICDC data model and finalizes the caDSR code mapping for consent_group_id.

### Changes
model-desc/icdc-model-props.yml
Added new property study_accession — dbGaP study accession number (optional, pattern ^phs[0-9]+$), mapped to caDSR DSS CDE code 11524544 (Research Activity dbGaP Accession Number Identifier, v1.00).
Replaced placeholder Code: 'TBD' on consent_group_id with the assigned caDSR code 16306756 (Study Consent Group Identifier).
model-desc/icdc-model.yml
Added study_accession to the property list of the study node.
### Why
Captures the dbGaP study accession identifier on the study node and replaces the temporary TBD code on consent_group_id with the now-assigned caDSR identifier, completing terminology binding for that property.