### PR TITLE
Merge develop to master to update version and release notes

### DIFF
--- a/model-desc/icdc-model.yml
+++ b/model-desc/icdc-model.yml
@@ -3,7 +3,7 @@
 # Lower case names are labels for the entities
 # document number - really a property of properties (where did this question appear)
 Handle: ICDC
-Version: v2.0.0
+Version: v2.1.0
 Nodes:
   program:
     Desc: Within the Integrated Canine Data Commons, studies are grouped into discrete programs, based upon the origins and/or scientific nature of each study/trial. These programs may or may not directly relate to any official, e.g. NCI, funding program. The Program node contains the properties required to appropriately characterize any given ICDC program.

--- a/model-desc/version.md
+++ b/model-desc/version.md
@@ -1,4 +1,9 @@
 ## Release Notes - Integrated Canine Data Commons (ICDC)
+### Data Model version 2.1.0
+Release Date 05/8/26
+
+This minor version release adds the study_accession property to the ICDC data model and finalizes the caDSR code mapping for the Consent Group node.
+
 ### Data Model version 2.0.0
 Release Date: 03/10/26  
 


### PR DESCRIPTION
Branch: update-version
Commit: 791e109 — update version and release notes

Summary
Bumps the ICDC data model to v2.1.0 and adds the corresponding entry to the release notes.

Changes
model-desc/icdc-model.yml — Version field updated from v2.0.0 → v2.1.0.
model-desc/version.md — Added a new release-notes section for v2.1.0 (Release Date 05/8/26) describing this as a minor release that adds the study_accession property and finalizes the caDSR code mapping for the Consent Group node.
Why
Publishes the changes from the merged ICDC-3983 PR (#202) under a new minor model version so downstream consumers can pin to v2.1.0 and see what changed in the release notes.